### PR TITLE
change the order of gobgp installation and add an option to rebuild

### DIFF
--- a/test/netlink/Dockerfile
+++ b/test/netlink/Dockerfile
@@ -7,6 +7,6 @@ MAINTAINER ISHIDA Wataru <ishida.wataru@lab.ntt.co.jp>
 
 RUN cd /go/src/github.com/osrg/gobgp; git pull origin evpn:evpn; git checkout evpn
 COPY goplane /go/src/github.com/osrg/goplane/
+RUN go install -a github.com/osrg/gobgp/gobgp
 RUN go get -v github.com/osrg/goplane/goplaned
 RUN go install github.com/osrg/goplane/goplaned
-RUN go install github.com/osrg/gobgp/gobgp


### PR DESCRIPTION
To avoid error during "sudo ./demo.py prepare" as follows,
```
# github.com/osrg/goplane/netlink
/go/src/github.com/osrg/goplane/netlink/dataplane.go:122: client.MonitorBestChanged undefined (type api.GrpcClient has no field or method MonitorBestChanged)
/go/src/github.com/osrg/goplane/netlink/virtualnetwork.go:577: client.MonitorBestChanged undefined (type api.GrpcClient has no field or method MonitorBestChanged)
github.com/osrg/goplane/ovs
# github.com/osrg/goplane/ovs
/go/src/github.com/osrg/goplane/ovs/dataplane.go:86: client.MonitorBestChanged undefined (type api.GrpcClient has no field or method MonitorBestChanged)
2015/05/12 03:19:40 The command [/bin/sh -c go get -v github.com/osrg/goplane/goplaned] returned a non-zero code: 2
```
Dockerfile seems to need to be changed the order of "RUN go install github.com/osrg/gobgp/gobgp" and added -a option to force rebuild.